### PR TITLE
feat(docker): build and run dummy containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,19 @@ The modern, distributed and scalable implementation of a game inspired by Connec
 - You can exchange your points for perks and skins
 - To ensure fairness, some bots might be added to balance the teams
 
+# Running
+In order to run all services within docker you can run an alternation of one of the following commands:
+
+```sh
+# Run services hosted under backed.localhost and frontend.localhost, built locally, run 2 joestar instances
+docker-compose -f docker-compose.yml -f docker-compose.dev.yml up --build --scale joestars=2
+
+# Run services under https://ourdomain.com, generating certificates throught Let's Encrypt, using images published to GitHub Packages
+docker-compose -f docker-compose.yml -f docker-compose.prod.yml up --scale joestars=5
+
+# Or write your own override file with your domain
+```
+
 # Technical Implementation
 
 ![Architecture Overview](https://www.plantuml.com/plantuml/png/VP91RzGm48Nl_XN3YkikMdfTHQLmwg6WqYCNuymw9ex7jSVRLgZ_dOcpZKeWlLWQlyylpy-vpAmJby6hTouONrg4WoTB-KDBfiUqYw8r_uYMOhSg_ieKLgIUsBirCL9ccp3V-nKWdz0pRfsP_HKxzWXtQBf00Zt1rnEcayC7fNBlGjH93p1G8DCb6X0u5Nobj7ZKnVCTFl8dxsmOC30OMJ0f5RNfjKNO7DvFPJGR-Aq04XhMmVgglChK_0XVA4P76z0PZed49hHouBvWgV1Kct3V8sBxe2s5oiP4Zqy2pb-y9XmV9bSr6osbsIiHnQz6M8IOQXNVQmgQEpsv1cfn_oQSCNOp-l5Db7MY6RqGz5cjmRVqac1iCcb_JYu7ZcvYnr-agKZxKxO3iMnVkTQDZew2zc1e64fmHeypS9Ues0xixRVFzTpDNZshbuvXsvmxhAkCYz9KxG8EMr4MeUhLLvMB_of_Zo20N4FTx65NTlF3d-Tbad4txPQEbxAKmVy1)

--- a/backend/Dockerfile.joestar
+++ b/backend/Dockerfile.joestar
@@ -1,0 +1,11 @@
+# TODO FROM gradle:jdk15 as build
+
+# TODO COPY build.gradle .
+# TODO COPY src ./src
+# TODO RUN gradle clean build --no-daemon
+
+# TODO FROM openjdk:15-jdk-alpine
+# TODO COPY --from=build /home/gradle/build/libs/gradle.jar /joestar.jar
+# TODO ENTRYPOINT ["java","-jar","/joestar.jar"]
+
+FROM nginx:mainline-alpine

--- a/backend/Dockerfile.rohan
+++ b/backend/Dockerfile.rohan
@@ -1,0 +1,12 @@
+# TODO FROM gradle:jdk15 as build
+
+# TODO COPY build.gradle .
+# TODO COPY src ./src
+# TODO RUN gradle clean build --no-daemon
+
+# TODO FROM openjdk:15-jdk-alpine
+# TODO COPY --from=build /home/gradle/build/libs/gradle.jar /joestar.jar
+# TODO VOLUME /etc/rohan/
+# TODO ENTRYPOINT ["java","-jar","/joestar.jar"]
+
+FROM nginx:mainline-alpine

--- a/docker-compose.common.yml
+++ b/docker-compose.common.yml
@@ -1,0 +1,39 @@
+version: '3.8'
+services:
+  doppio:
+    image: "ghcr.io/pascalhonegger/cc-doppio"
+    labels:
+      - "traefik.enable=true"
+    networks:
+      - speedwagon_net
+
+  speedwagon:
+    image: "traefik:v2.4"
+    command:
+      - "--providers.docker=true"
+      - "--providers.docker.network=speedwagon_net"
+      - "--providers.docker.exposedbydefault=false"
+      - "--entrypoints.web.address=:80"
+      - "--entrypoints.websecure.address=:443"
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - "/var/run/docker.sock:/var/run/docker.sock:ro"
+    networks:
+      - speedwagon_net
+
+  joestars:
+    image: "ghcr.io/pascalhonegger/cc-joestar"
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.joestars.rule=Host(`backend.localhost`)"
+      - "traefik.http.routers.joestars.entrypoints=web"
+    networks:
+      - speedwagon_net
+      - rohan_net
+
+  rohan:
+    image: "ghcr.io/pascalhonegger/cc-rohan"
+    networks:
+      - rohan_net

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,36 @@
+version: '3.8'
+services:
+  doppio:
+    extends:
+      file: docker-compose.common.yml
+      service: doppio
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile
+    labels:
+      - "traefik.http.routers.doppio.rule=Host(`frontend.localhost`)"
+      - "traefik.http.routers.doppio.entrypoints=web"
+
+  speedwagon:
+    extends:
+      file: docker-compose.common.yml
+      service: speedwagon
+
+  joestars:
+    extends:
+      file: docker-compose.common.yml
+      service: joestars
+    labels:
+      - "traefik.http.routers.joestars.rule=Host(`backend.localhost`)"
+      - "traefik.http.routers.joestars.entrypoints=web"
+    build:
+      context: ./backend
+      dockerfile: Dockerfile.joestar
+
+  rohan:
+    extends:
+      file: docker-compose.common.yml
+      service: rohan
+    build:
+      context: ./backend
+      dockerfile: Dockerfile.rohan

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,39 @@
+version: '3.8'
+services:
+  doppio:
+    extends:
+      file: docker-compose.common.yml
+      service: doppio
+    labels:
+      - "traefik.http.routers.doppio.rule=Host(`www.ourdomain.com`, `ourdomain.com`)"
+      - "traefik.http.routers.doppio.entrypoints=websecure"
+
+  speedwagon:
+    extends:
+      file: docker-compose.common.yml
+      service: speedwagon
+    command:
+      - "--providers.docker=true"
+      - "--providers.docker.network=speedwagon_net"
+      - "--providers.docker.exposedbydefault=false"
+      - "--entrypoints.web.address=:80"
+      - "--entrypoints.websecure.address=:443"
+      - "--entrypoints.web.http.redirections.entryPoint.to=websecure"
+      - "--entrypoints.web.http.redirections.entryPoint.scheme=https"
+      - "--entrypoints.websecure.http.tls.certresolver=letsencrypt"
+      - "--certificatesResolvers.letsencrypt.acme.email=acme@ourdomain.com"
+      - "--certificatesResolvers.letsencrypt.acme.storage=acme.json"
+      - "--certificatesResolvers.letsencrypt.acme.tlschallenge=true"
+
+  joestars:
+    extends:
+      file: docker-compose.common.yml
+      service: joestars
+    labels:
+      - "traefik.http.routers.joestars.rule=Host(`backend.ourdomain.com`)"
+      - "traefik.http.routers.joestars.entrypoints=websecure"
+
+  rohan:
+    extends:
+      file: docker-compose.common.yml
+      service: rohan

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+version: '3.8'
+networks:
+  speedwagon_net:
+    name: speedwagon_net
+  rohan_net:
+    name: rohan_net

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:15-alpine as build
+WORKDIR /app
+COPY dummy.html ./dist/out/index.html
+# TODO COPY package*.json /app/
+# TODO RUN npm ci
+# TODO COPY . /app
+# TODO RUN npm run build -- --outputPath=./dist/out --configuration production
+
+FROM nginx:mainline-alpine
+COPY --from=build /app/dist/out/ /usr/share/nginx/html

--- a/frontend/dummy.html
+++ b/frontend/dummy.html
@@ -1,0 +1,1 @@
+Frontend Container is working!


### PR DESCRIPTION
The content of the containers is temporary, but the traefik reverse proxy setup is final

ourdomain.com is used as a placeholder and will be removed once we either buy a domain or decide not to buy a domain 😉

The Dockerfile are obviously quite simple, but with the commented out steps it should be fairly simple to create the images once we have real code

Resolves #2, resolves #3.