### PR TITLE
fix(api): use snake case naming for number_of_rows

### DIFF
--- a/backend/grpc/game.proto
+++ b/backend/grpc/game.proto
@@ -69,7 +69,7 @@ message GameState {
   repeated GameStateColumn columns = 1;
   map<string, PlayerState> players = 2;
   repeated Skin skins = 3;
-  int32 numberOfRows = 4;
+  int32 number_of_rows = 4;
 }
 
 // Events


### PR DESCRIPTION
Uses snake case naming for the GRPC property, like the other props do. This also affected the GRPC web codegen, so getNumberOfRows was called getNumberofrows instead. 