### PR TITLE
feat(joestar): make all jwt duration configurable as Duration

### DIFF
--- a/backend/joestar/src/main/kotlin/ch/chaosconnect/joestar/JwtConfig.kt
+++ b/backend/joestar/src/main/kotlin/ch/chaosconnect/joestar/JwtConfig.kt
@@ -1,6 +1,7 @@
 package ch.chaosconnect.joestar
 
 import io.micronaut.context.annotation.ConfigurationProperties
+import java.time.Duration
 import javax.validation.constraints.NotBlank
 
 @ConfigurationProperties("jwt")
@@ -15,5 +16,7 @@ class JwtConfig {
     lateinit var audience: String
 
     @NotBlank
-    var clockSkew: Long = 0L
+    lateinit var validFor: Duration
+
+    var clockSkew: Duration = Duration.ZERO
 }

--- a/backend/joestar/src/main/kotlin/ch/chaosconnect/joestar/TokenService.kt
+++ b/backend/joestar/src/main/kotlin/ch/chaosconnect/joestar/TokenService.kt
@@ -5,7 +5,6 @@ import io.jsonwebtoken.io.Decoders
 import io.jsonwebtoken.security.Keys
 import org.slf4j.LoggerFactory
 import java.time.Instant
-import java.time.temporal.ChronoUnit
 import java.util.*
 import javax.crypto.SecretKey
 import javax.inject.Singleton
@@ -46,7 +45,7 @@ class TokenServiceImpl(private val jwtConfig: JwtConfig) : TokenService {
             .setSubject(identifier)
             .setAudience(jwtConfig.audience)
             .setIssuedAt(Date.from(now))
-            .setExpiration(Date.from(now.plus(1, ChronoUnit.DAYS)))
+            .setExpiration(Date.from(now.plus(jwtConfig.validFor)))
             .compact()
     }
 
@@ -86,7 +85,7 @@ class TokenServiceImpl(private val jwtConfig: JwtConfig) : TokenService {
             .setSigningKey(key)
             .requireIssuer(jwtConfig.issuer)
             .requireAudience(jwtConfig.audience)
-            .setAllowedClockSkewSeconds(jwtConfig.clockSkew)
+            .setAllowedClockSkewSeconds(jwtConfig.clockSkew.seconds)
             .build()
     }
 }

--- a/backend/joestar/src/main/resources/application.yml
+++ b/backend/joestar/src/main/resources/application.yml
@@ -22,4 +22,5 @@ endpoints:
 jwt:
   issuer: Joestar
   audience: Doppio
-  clock-skew: 60
+  clock-skew: 1m
+  valid-for: 7d

--- a/backend/joestar/src/test/kotlin/ch/chaosconnect/joestar/TokenServiceTest.kt
+++ b/backend/joestar/src/test/kotlin/ch/chaosconnect/joestar/TokenServiceTest.kt
@@ -4,6 +4,7 @@ import io.jsonwebtoken.io.DecodingException
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import java.time.Duration
 
 const val validSecret =
     "kiMu3ODiG8NdA41/6bj5BcsKDUplTh32bmocO3EKbgbOdHGBfST1/dtfuh+hMOTqEGurJgMPI0XCUewlBWEdrw=="
@@ -17,6 +18,7 @@ class TokenServiceTest {
                 secret = validSecret
                 issuer = "Me"
                 audience = "You"
+                validFor = Duration.ofDays(1)
             })
         val token = service.createSignedToken("SomeUsername")
         val decoded = service.parseToken(token)
@@ -30,6 +32,7 @@ class TokenServiceTest {
                 secret = invalidSecret
                 issuer = "Me"
                 audience = "You"
+                validFor = Duration.ofDays(1)
             })
         }
     }


### PR DESCRIPTION
Configure durations with human readable values (e.g. `1m`) instead of having fixed units (e.g. `60` with base unit 60).

Also increases the default jwt validity from 1 day to 7 days.