### PR TITLE
feat(rohan): store hashed version of user password

### DIFF
--- a/backend/rohan/build.gradle.kts
+++ b/backend/rohan/build.gradle.kts
@@ -35,6 +35,7 @@ dependencies {
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.grpc.kotlin)
     implementation(libs.jjwt.api)
+    implementation(libs.argon2.jvm)
     runtimeOnly(libs.logback)
     runtimeOnly(libs.jjwt.impl)
     runtimeOnly(libs.jjwt.jackson)

--- a/backend/rohan/src/main/kotlin/ch/chaosconnect/rohan/model/User.kt
+++ b/backend/rohan/src/main/kotlin/ch/chaosconnect/rohan/model/User.kt
@@ -24,5 +24,5 @@ data class TemporaryUser(
 @Serializable
 data class UserCredentials(
     val name: String,
-    val password: String
+    val passwordHash: String
 )

--- a/backend/rohan/src/test/kotlin/ch/chaosconnect/rohan/services/StorageServiceImplTest.kt
+++ b/backend/rohan/src/test/kotlin/ch/chaosconnect/rohan/services/StorageServiceImplTest.kt
@@ -78,6 +78,48 @@ internal class StorageServiceImplTest {
     }
 
     @Test
+    fun `get user does not include sensitive information`() {
+        val addedUser = service.addUser {
+            RegularUser(
+                identifier = it,
+                displayName = "Dummy User",
+                credentials = UserCredentials("dummy", "some-password-hash")
+            )
+        }
+        val loadedUser = service.getUser(addedUser.identifier)
+        assertEquals(
+            "",
+            (loadedUser?.user as RegularUser).credentials.passwordHash
+        )
+    }
+
+    @Test
+    fun `update user does not include sensitive information`() {
+        val addedUser = service.addUser {
+            RegularUser(
+                identifier = it,
+                displayName = "Dummy User",
+                credentials = UserCredentials("dummy", "some-password-hash")
+            )
+        }
+        val updatedUser = service.updateUser(addedUser.identifier) { it }
+        assertEquals("", (updatedUser as RegularUser).credentials.passwordHash)
+    }
+
+    @Test
+    fun `update score does not include sensitive information`() {
+        val addedUser = service.addUser {
+            RegularUser(
+                identifier = it,
+                displayName = "Dummy User",
+                credentials = UserCredentials("dummy", "some-password-hash")
+            )
+        }
+        val updatedUser = service.updateScore(addedUser.identifier) { it }
+        assertEquals("", (updatedUser.user as RegularUser).credentials.passwordHash)
+    }
+
+    @Test
     fun `can update a temporary to a regular user`() {
         val addedUser = service.addUser { TemporaryUser(it, "Dummy User") }
         val updatedUser = service.updateUser(addedUser.identifier) {
@@ -107,7 +149,7 @@ internal class StorageServiceImplTest {
         }
         assertEquals(addedUser, service.findUser("myuser"))
         assertEquals(addedUser, service.findUser("myuser") {
-            it.credentials.password == "123"
+            it.credentials.passwordHash == "123"
         })
         assertNull(service.findUser("myuser") { false })
         assertNull(service.findUser("OtherUser"))

--- a/backend/settings.gradle.kts
+++ b/backend/settings.gradle.kts
@@ -33,6 +33,7 @@ dependencyResolutionManagement {
             version("jjwt", "0.11.2")
             version("mockk", "1.11.0")
             version("turbine", "0.4.1")
+            version("argon2-jvm", "2.10.1")
 
             alias("kotlin-stdlib").to(
                 "org.jetbrains.kotlin",
@@ -113,6 +114,9 @@ dependencyResolutionManagement {
                 .versionRef("jjwt")
             alias("jjwt-jackson").to("io.jsonwebtoken", "jjwt-jackson")
                 .versionRef("jjwt")
+
+            alias("argon2-jvm").to("de.mkammerer", "argon2-jvm")
+                .versionRef("argon2-jvm")
 
             alias("logback").to("ch.qos.logback", "logback-classic")
                 .withoutVersion()


### PR DESCRIPTION
Very basic hash usage. The Password string is not explicitly removed from memory because I'm not sure how to securely implement such a feature with Micronaut and gRPC in the middle. We just have to hope nobody ready our running process memory 🤷‍♂️.

I decided that the storage service methods should not return sensitive information once stored to prevent accidentally sending them to a client or logging them.