### PR TITLE
Cleanup docker compose once again

### DIFF
--- a/.idea/runConfigurations/Generate_Self_Signed_Certificate.xml
+++ b/.idea/runConfigurations/Generate_Self_Signed_Certificate.xml
@@ -2,12 +2,16 @@
   <configuration default="false" name="Generate Self Signed Certificate" type="docker-deploy" factoryName="docker-compose.yml" server-name="Docker">
     <deployment type="docker-compose.yml">
       <settings>
+        <option name="envFilePath" value="" />
         <option name="services">
           <list>
             <option value="gen_self_signed_cert" />
           </list>
         </option>
         <option name="sourceFilePath" value="docker-compose.gen.yml" />
+        <option name="upDetach" value="false" />
+        <option name="upExitCodeFromService" value="" />
+        <option name="upTimeout" value="" />
       </settings>
     </deployment>
     <method v="2" />

--- a/.idea/runConfigurations/Generate_gRPC_Web.xml
+++ b/.idea/runConfigurations/Generate_gRPC_Web.xml
@@ -2,12 +2,16 @@
   <configuration default="false" name="Generate gRPC Web" type="docker-deploy" factoryName="docker-compose.yml" server-name="Docker">
     <deployment type="docker-compose.yml">
       <settings>
+        <option name="envFilePath" value="" />
         <option name="services">
           <list>
             <option value="gen_grpc_joestar_client" />
           </list>
         </option>
         <option name="sourceFilePath" value="docker-compose.gen.yml" />
+        <option name="upDetach" value="false" />
+        <option name="upExitCodeFromService" value="" />
+        <option name="upTimeout" value="" />
       </settings>
     </deployment>
     <method v="2" />

--- a/.idea/runConfigurations/Speedwagon_Dev_Linux.xml
+++ b/.idea/runConfigurations/Speedwagon_Dev_Linux.xml
@@ -2,7 +2,12 @@
   <configuration default="false" name="Speedwagon Dev Linux" type="docker-deploy" factoryName="docker-compose.yml" server-name="Docker">
     <deployment type="docker-compose.yml">
       <settings>
+        <option name="envFilePath" value="" />
+        <option name="commandLineOptions" value="--build" />
         <option name="sourceFilePath" value="docker-compose.proxy-linux.yml" />
+        <option name="upDetach" value="false" />
+        <option name="upExitCodeFromService" value="" />
+        <option name="upTimeout" value="" />
       </settings>
     </deployment>
     <method v="2" />

--- a/.idea/runConfigurations/Speedwagon_dev.xml
+++ b/.idea/runConfigurations/Speedwagon_dev.xml
@@ -2,7 +2,12 @@
   <configuration default="false" name="Speedwagon Dev" type="docker-deploy" factoryName="docker-compose.yml" server-name="Docker">
     <deployment type="docker-compose.yml">
       <settings>
+        <option name="envFilePath" value="" />
+        <option name="commandLineOptions" value="--build" />
         <option name="sourceFilePath" value="docker-compose.proxy.yml" />
+        <option name="upDetach" value="false" />
+        <option name="upExitCodeFromService" value="" />
+        <option name="upTimeout" value="" />
       </settings>
     </deployment>
     <method v="2" />

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,38 +1,44 @@
-version: '3.3'
+version: '3'
 services:
   doppio:
-    extends:
-      file: docker-compose.yml
-      service: doppio
+    image: "ghcr.io/pascalhonegger/cc-doppio"
     build:
       context: ./frontend
+    networks:
+      - speedwagon_net
 
   speedwagon:
-    extends:
-      file: docker-compose.yml
-      service: speedwagon
+    image: "ghcr.io/pascalhonegger/cc-speedwagon"
     build:
       context: ./proxy
+    volumes:
+      - ./certs:/etc/envoy/certs:ro
     ports:
+      - 80:80
+      - 443:443
       - 9901:9901
+    networks:
+      - speedwagon_net
 
   joestar:
-    extends:
-      file: docker-compose.yml
-      service: joestar
+    image: "ghcr.io/pascalhonegger/cc-joestar"
     build:
       context: ./backend
       dockerfile: Dockerfile.joestar
     environment:
+      ROHAN_SERVER: rohan
       JWT_SECRET: kiMu3ODiG8NdA41/6bj5BcsKDUplTh32bmocO3EKbgbOdHGBfST1/dtfuh+hMOTqEGurJgMPI0XCUewlBWEdrw==
+    networks:
+      - speedwagon_net
+      - rohan_net
 
   rohan:
-    extends:
-      file: docker-compose.yml
-      service: rohan
+    image: "ghcr.io/pascalhonegger/cc-rohan"
     build:
       context: ./backend
       dockerfile: Dockerfile.rohan
+    networks:
+      - rohan_net
 
 networks:
   speedwagon_net:

--- a/docker-compose.gen.yml
+++ b/docker-compose.gen.yml
@@ -1,4 +1,4 @@
-version: '3.3'
+version: '3'
 services:
   gen_grpc_joestar_client:
     image: namely/protoc-all:1.34_4

--- a/docker-compose.proxy-linux.yml
+++ b/docker-compose.proxy-linux.yml
@@ -1,4 +1,4 @@
-version: '3.3'
+version: '3'
 services:
   speedwagon:
     image: envoyproxy/envoy-alpine:v1.17-latest

--- a/docker-compose.proxy-linux.yml
+++ b/docker-compose.proxy-linux.yml
@@ -1,7 +1,9 @@
 version: '3'
 services:
   speedwagon:
-    image: envoyproxy/envoy-alpine:v1.17-latest
+    image: "ghcr.io/pascalhonegger/cc-speedwagon"
+    build:
+      context: ./proxy
     volumes:
       - ./proxy/envoy-dev-linux.yaml:/etc/envoy/envoy.yaml:ro
     ports:

--- a/docker-compose.proxy.yml
+++ b/docker-compose.proxy.yml
@@ -1,4 +1,4 @@
-version: '3.3'
+version: '3'
 services:
   speedwagon:
     image: envoyproxy/envoy-alpine:v1.17-latest

--- a/docker-compose.proxy.yml
+++ b/docker-compose.proxy.yml
@@ -1,7 +1,9 @@
 version: '3'
 services:
   speedwagon:
-    image: envoyproxy/envoy-alpine:v1.17-latest
+    image: "ghcr.io/pascalhonegger/cc-speedwagon"
+    build:
+      context: ./proxy
     volumes:
       - ./proxy/envoy-dev.yaml:/etc/envoy/envoy.yaml:ro
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.3'
+version: '3'
 services:
   doppio:
     image: "ghcr.io/pascalhonegger/cc-doppio"

--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM envoyproxy/envoy-alpine:v1.17-latest
+FROM envoyproxy/envoy-alpine:v1.18-latest
 
 EXPOSE 80
 EXPOSE 443


### PR DESCRIPTION
This should allow users to again use the templated docker-compose files in development mode without relying on some weird undocumented Docker for Windows exclusive feature.